### PR TITLE
Fixed converting from "bytes"

### DIFF
--- a/lib/util/typed_data.dart
+++ b/lib/util/typed_data.dart
@@ -146,7 +146,13 @@ class TypedDataUtil {
         }
 
         if (type == 'bytes') {
-          return ['bytes32', keccak256(value)];
+          final List<int> convertedList = new List<int>.from(value);
+          if (convertedList != null) {
+            final uint8List = Uint8List.fromList(convertedList);
+            return ['bytes32', keccak256(uint8List)];
+          } else {
+            throw new ArgumentError('Not supported type for bytes');
+          }
         }
 
         if (type == 'string') {


### PR DESCRIPTION
In case if try to encode json data, where one of type declared as "bytes" during encoding returned error:
 `"_TypeError (type 'List<dynamic>' is not a subtype of type 'Uint8List')"`
This fix make convertation directly to Uint8List.
Example of some encoding:
```
const List<Map<String, dynamic>> _ForwardRequest = [
      {"name": "from", "type": "address"},
      {"name": "to", "type": "address"},
      {"name": "value", "type": "uint256"},
      {"name": "data", "type": "bytes"},
    ];
```