### PR TITLE
Fix for checking isHexPrefixed

### DIFF
--- a/lib/util/utils.dart
+++ b/lib/util/utils.dart
@@ -4,7 +4,7 @@ import 'dart:typed_data';
 import 'package:convert/convert.dart' show hex;
 
 bool isHexPrefixed(String str) {
-  return str.substring(0, 2) == '0x';
+  return str.startsWith('0x');
 }
 
 Uint8List hexToBytes(String hexStr) {


### PR DESCRIPTION
Now if string is less then 2 chars - library crashed (exception), because of trying to substring of 2 characters (but string could be like "0", or "1". Proposed solution is replace it with: `str.startsWith('0x');`